### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ description = "A backend-agnostic extension for HTTP libraries that provides sup
 
 keywords = ["form-data", "hyper", "iron", "http", "upload"]
 
-repository = "http://github.com/bachue/multipart"
+repository = "https://github.com/bachue/multipart"
 
-documentation = "http://docs.rs/multipart/"
+documentation = "https://docs.rs/multipart/"
 
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97